### PR TITLE
Remove Python 3.2 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.2'
 - '3.3'
 - '3.4'
 - '3.5'


### PR DESCRIPTION
requests doesn't support Python 3.2 and it is causing the Travis build to fail.
